### PR TITLE
[AND-4514] Bugfix: nURL missed if we check canPlayAd before loading ad

### DIFF
--- a/Vungle/build.gradle.kts
+++ b/Vungle/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 private val versionMajor = 6
 private val versionMinor = 12
 private val versionPatch = 1
-private val versionAdapterPatch = 0
+private val versionAdapterPatch = 1
 
 val libraryVersionName by extra("${versionMajor}.${versionMinor}.${versionPatch}.${versionAdapterPatch}")
 val libraryVersionCode by extra((versionMajor * 1000000) + (versionMinor * 10000) + (versionPatch * 100) + versionAdapterPatch)

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -197,13 +197,8 @@ public class VungleMediationAdapter
 
         if ( isBiddingAd )
         {
-            if ( Vungle.canPlayAd( placementId, bidResponse ) )
-            {
-                log( "Interstitial ad loaded" );
-                listener.onInterstitialAdLoaded();
-
-                return;
-            }
+            // Not allowed to avoid calling loadAd() even if canPlayAd()=true when max_hb_cache=1.
+            // That will cause nURL missed issue.
         }
         else if ( Vungle.canPlayAd( placementId ) )
         {
@@ -289,13 +284,7 @@ public class VungleMediationAdapter
 
         if ( isBiddingAd )
         {
-            if ( Vungle.canPlayAd( placementId, bidResponse ) )
-            {
-                log( "App open ad loaded" );
-                listener.onAppOpenAdLoaded();
-
-                return;
-            }
+            // no-op
         }
         else if ( Vungle.canPlayAd( placementId ) )
         {
@@ -383,13 +372,7 @@ public class VungleMediationAdapter
 
         if ( isBiddingAd )
         {
-            if ( Vungle.canPlayAd( placementId, bidResponse ) )
-            {
-                log( "Rewarded ad loaded" );
-                listener.onRewardedAdLoaded();
-
-                return;
-            }
+            // no-op
         }
         else if ( Vungle.canPlayAd( placementId ) )
         {
@@ -491,11 +474,7 @@ public class VungleMediationAdapter
 
         if ( isBiddingAd )
         {
-            if ( Banners.canPlayAd( placementId, bidResponse, adSize ) )
-            {
-                showAdViewAd( adFormat, adConfig, parameters, listener, playAdCallback );
-                return;
-            }
+            // no-op
         }
         else if ( Banners.canPlayAd( placementId, adSize ) )
         {

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -195,18 +195,8 @@ public class VungleMediationAdapter
             return;
         }
 
-        if ( isBiddingAd )
-        {
-            // Not allowed to avoid calling loadAd() even if canPlayAd()=true when max_hb_cache=1.
-            // That will cause nURL missed issue.
-        }
-        else if ( Vungle.canPlayAd( placementId ) )
-        {
-            log( "Interstitial ad loaded" );
-            listener.onInterstitialAdLoaded();
-
-            return;
-        }
+        // Not allowed to skip calling loadAd() even if canPlayAd()=true when max_hb_cache=1 or auto-cached ads.
+        // That will cause nURL missed issue.
 
         updateUserPrivacySettings( parameters );
         loadFullscreenAd( parameters, getContext( activity ), new LoadAdCallback()
@@ -278,18 +268,6 @@ public class VungleMediationAdapter
         {
             log( "App open ad failed to load due to an invalid placement id: " + placementId );
             listener.onAppOpenAdLoadFailed( MaxAdapterError.INVALID_CONFIGURATION );
-
-            return;
-        }
-
-        if ( isBiddingAd )
-        {
-            // no-op
-        }
-        else if ( Vungle.canPlayAd( placementId ) )
-        {
-            log( "App open ad loaded" );
-            listener.onAppOpenAdLoaded();
 
             return;
         }
@@ -366,18 +344,6 @@ public class VungleMediationAdapter
         {
             log( "Rewarded ad failed to load due to an invalid placement id: " + placementId );
             listener.onRewardedAdLoadFailed( MaxAdapterError.INVALID_CONFIGURATION );
-
-            return;
-        }
-
-        if ( isBiddingAd )
-        {
-            // no-op
-        }
-        else if ( Vungle.canPlayAd( placementId ) )
-        {
-            log( "Rewarded ad loaded" );
-            listener.onRewardedAdLoaded();
 
             return;
         }
@@ -470,16 +436,6 @@ public class VungleMediationAdapter
         if ( serverParameters.containsKey( "is_muted" ) )
         {
             adConfig.setMuted( serverParameters.getBoolean( "is_muted" ) );
-        }
-
-        if ( isBiddingAd )
-        {
-            // no-op
-        }
-        else if ( Banners.canPlayAd( placementId, adSize ) )
-        {
-            showAdViewAd( adFormat, adConfig, parameters, listener, playAdCallback );
-            return;
         }
 
         updateUserPrivacySettings( parameters );


### PR DESCRIPTION
pr for ticket: https://vungle.atlassian.net/browse/AND-4514

Context:
nURL missed in MAX adapter in the multiple bidding case.

Investigation:
1. The max_hb_cache = 1 for most fullscreen ads.
2. The max_hb_cache = 2 for most banner ads.
3. The max adapter checks canPlayAd first when loading ads. 
4. SDK sends nURL when loaded ad.

In max_hb_cache = 1 case:
The ads will be auto-cached and canPlayAd() returns true when loading multiple bidding ads, so MAX just returns onXXAdLoaded() to pubs. This cause there's no chance to send the nURL.
So the better way to fix it is to remove the check. SDK will do the canPlayAd check inside.

UT:
I have tested on both max_hb_cache=1 or 2 and they work fine. Need more tests to verify it on the RTA case.
