### PR TITLE
[AND-5368] Adapter Logging 

### DIFF
--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -219,7 +219,8 @@ public class VungleMediationAdapter
 
         interstitialAd = new InterstitialAd( getContext( activity ), placementId, new AdConfig() );
         interstitialAd.setAdListener( new InterstitialListener( listener ) );
-
+        interstitialAd.setAdapterAdFormat("MaxInterstitialAdapter");
+        
         interstitialAd.load( bidResponse );
     }
 
@@ -263,6 +264,7 @@ public class VungleMediationAdapter
 
         appOpenAd = new InterstitialAd( getContext( activity ), placementId, new AdConfig() );
         appOpenAd.setAdListener( new AppOpenAdListener( listener ) );
+        appOpenAd.setAdapterAdFormat("MaxAppOpenAdapter");
 
         appOpenAd.load( bidResponse );
     }
@@ -307,6 +309,7 @@ public class VungleMediationAdapter
 
         rewardedAd = new RewardedAd( getContext( activity ), placementId, new AdConfig() );
         rewardedAd.setAdListener( new RewardedListener( listener ) );
+        rewardedAd.setAdapterAdFormat("MaxRewardedAdapter");
 
         rewardedAd.load( bidResponse );
     }
@@ -362,6 +365,7 @@ public class VungleMediationAdapter
             final NativeAdViewListener nativeAdViewListener = new NativeAdViewListener( parameters, adFormat, context, listener );
             nativeAd = new NativeAd( getContext( activity ), placementId );
             nativeAd.setAdListener( nativeAdViewListener );
+            nativeAd.setAdapterAdFormat("MaxAdViewAdapter-Native");
 
             nativeAd.load( bidResponse );
 
@@ -379,6 +383,7 @@ public class VungleMediationAdapter
         VungleAdSize adSize = toVungleAdSize( adFormat, isAdaptiveAdViewEnabled, parameters, context );
         adViewAd = new VungleBannerView( context, placementId, adSize );
         adViewAd.setAdListener( new AdViewAdListener( adFormatLabel, listener ) );
+        adViewAd.setAdapterAdFormat("MaxAdViewAdapter");
 
         adViewAd.load( bidResponse );
     }
@@ -407,6 +412,7 @@ public class VungleMediationAdapter
 
         nativeAd = new NativeAd( getContext( activity ), placementId );
         nativeAd.setAdListener( new NativeListener( parameters, getContext( activity ), listener ) );
+        nativeAd.setAdapterAdFormat("MaxNativeAdAdapter");
 
         nativeAd.load( bidResponse );
     }

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -385,20 +385,7 @@ public class VungleMediationAdapter
         adViewAd = new VungleBannerView( context, placementId, adSize );
         adViewAd.setAdListener( new AdViewAdListener( adFormatLabel, listener ) );
         adViewAd.setAdapterAdFormat("MaxAdViewAdapter");
-        if (isAdaptiveAdViewForBannerPlacement(parameters)) {
-            Object adaptiveTypeObj = parameters.getLocalExtraParameters().get("adaptive_banner_type");
-            String adaptiveType = (adaptiveTypeObj != null) ? String.valueOf(adaptiveTypeObj) : "adaptive";
-            adViewAd.setAdapterAdFormat("MaxAdViewAdapter-" + adaptiveType);
-            // This is the case in which AdUnit is set to "adaptive", but Placement is not inline.
-            Object adaptiveWidthObj = parameters.getLocalExtraParameters().get("adaptive_banner_width");
-            Object adaptiveHeightObj = parameters.getLocalExtraParameters().get("adaptive_banner_height");
-            String adaptiveWidth = (adaptiveWidthObj != null) ? String.valueOf(adaptiveWidthObj) : "unknown";
-            String adaptiveHeight = (adaptiveHeightObj != null) ? String.valueOf(adaptiveHeightObj) : "unknown";
-            String adaptiveSizeMessage = String.format("AdaptivePlacementMismatch:w-%s|h-%s",
-                    adaptiveWidth,
-                    adaptiveHeight);
-            VungleMediationLogger.logError(adViewAd, adaptiveSizeMessage);
-        }
+        logAdaptiveAdViewForBannerPlacement( parameters, adViewAd );
 
         adViewAd.load( bidResponse );
     }
@@ -447,7 +434,7 @@ public class VungleMediationAdapter
         Object isAdaptiveBannerObj = parameters.getLocalExtraParameters().get( "adaptive_banner" );
         boolean isAdaptiveLocalParams = isAdaptiveBannerObj instanceof String && "true".equalsIgnoreCase( (String) isAdaptiveBannerObj );
 
-        if ( !isAdaptiveServerParams && !isAdaptiveLocalParams)
+        if ( !isAdaptiveServerParams && !isAdaptiveLocalParams )
         {
             return false;
         }
@@ -463,16 +450,26 @@ public class VungleMediationAdapter
         }
     }
 
-    private boolean isAdaptiveAdViewForBannerPlacement(final MaxAdapterResponseParameters parameters) {
-        boolean isAdaptiveServerParams = parameters.getServerParameters().getBoolean("adaptive_banner", false);
-        Object isAdaptiveBannerObj = parameters.getLocalExtraParameters().get("adaptive_banner");
-        boolean isAdaptiveLocalParams = isAdaptiveBannerObj instanceof String && "true".equalsIgnoreCase((String) isAdaptiveBannerObj);
-        boolean isInlinePlacement = VungleAds.isInline(parameters.getThirdPartyAdPlacementId());
+    private void logAdaptiveAdViewForBannerPlacement(final MaxAdapterResponseParameters parameters, final VungleBannerView adViewAd)
+    {
+        boolean isAdaptiveServerParams = parameters.getServerParameters().getBoolean( "adaptive_banner", false );
+        Object isAdaptiveBannerObj = parameters.getLocalExtraParameters().get( "adaptive_banner" );
+        boolean isAdaptiveLocalParams = isAdaptiveBannerObj instanceof String && "true".equalsIgnoreCase( (String) isAdaptiveBannerObj );
+        boolean isInlinePlacement = VungleAds.isInline( parameters.getThirdPartyAdPlacementId() );
 
-        if ((isAdaptiveServerParams || isAdaptiveLocalParams) && !isInlinePlacement) {
-            return true;
+        if ( ( isAdaptiveServerParams || isAdaptiveLocalParams ) && !isInlinePlacement )
+        {
+            Object adaptiveTypeObj = parameters.getLocalExtraParameters().get( "adaptive_banner_type" );
+            String adaptiveType = ( adaptiveTypeObj != null ) ? String.valueOf( adaptiveTypeObj ) : "adaptive";
+            adViewAd.setAdapterAdFormat( "MaxAdViewAdapter-" + adaptiveType );
+
+            Object adaptiveWidthObj = parameters.getLocalExtraParameters().get( "adaptive_banner_width" );
+            Object adaptiveMaxHeightObj = parameters.getLocalExtraParameters().get( "inline_adaptive_banner_max_height" );
+            String adaptiveWidth = ( adaptiveWidthObj != null ) ? String.valueOf( adaptiveWidthObj ) : "unknown";
+            String adaptiveMaxHeight = ( adaptiveMaxHeightObj != null ) ? String.valueOf( adaptiveMaxHeightObj ) : "unknown";
+            String adaptiveSizeMessage = String.format( "AdaptiveBannerSizeMismatch:w-%s|maxh-%s", adaptiveWidth, adaptiveMaxHeight );
+            VungleMediationLogger.logError( adViewAd, adaptiveSizeMessage );
         }
-        return false;
     }
 
     private void updateUserPrivacySettings(final MaxAdapterParameters parameters)

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -366,7 +366,7 @@ public class VungleMediationAdapter
             final NativeAdViewListener nativeAdViewListener = new NativeAdViewListener( parameters, adFormat, context, listener );
             nativeAd = new NativeAd( getContext( activity ), placementId );
             nativeAd.setAdListener( nativeAdViewListener );
-            nativeAd.setAdapterAdFormat("MaxNativeAdAdapter-adView");
+            nativeAd.setAdapterAdFormat("MaxNativeAdAdapter-banner");
 
             nativeAd.load( bidResponse );
 

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -366,7 +366,7 @@ public class VungleMediationAdapter
             final NativeAdViewListener nativeAdViewListener = new NativeAdViewListener( parameters, adFormat, context, listener );
             nativeAd = new NativeAd( getContext( activity ), placementId );
             nativeAd.setAdListener( nativeAdViewListener );
-            nativeAd.setAdapterAdFormat("MaxAdViewAdapter-Native");
+            nativeAd.setAdapterAdFormat("MaxNativeAdAdapter-adView");
 
             nativeAd.load( bidResponse );
 
@@ -385,6 +385,20 @@ public class VungleMediationAdapter
         adViewAd = new VungleBannerView( context, placementId, adSize );
         adViewAd.setAdListener( new AdViewAdListener( adFormatLabel, listener ) );
         adViewAd.setAdapterAdFormat("MaxAdViewAdapter");
+        if (isAdaptiveAdViewForBannerPlacement(parameters)) {
+            Object adaptiveTypeObj = parameters.getLocalExtraParameters().get("adaptive_banner_type");
+            String adaptiveType = (adaptiveTypeObj != null) ? String.valueOf(adaptiveTypeObj) : "adaptive";
+            adViewAd.setAdapterAdFormat("MaxAdViewAdapter-" + adaptiveType);
+            // This is the case in which AdUnit is set to "adaptive", but Placement is not inline.
+            Object adaptiveWidthObj = parameters.getLocalExtraParameters().get("adaptive_banner_width");
+            Object adaptiveHeightObj = parameters.getLocalExtraParameters().get("adaptive_banner_height");
+            String adaptiveWidth = (adaptiveWidthObj != null) ? String.valueOf(adaptiveWidthObj) : "unknown";
+            String adaptiveHeight = (adaptiveHeightObj != null) ? String.valueOf(adaptiveHeightObj) : "unknown";
+            String adaptiveSizeMessage = String.format("AdaptivePlacementMismatch:w-%s|h-%s",
+                    adaptiveWidth,
+                    adaptiveHeight);
+            VungleMediationLogger.logError(adViewAd, adaptiveSizeMessage);
+        }
 
         adViewAd.load( bidResponse );
     }
@@ -444,21 +458,21 @@ public class VungleMediationAdapter
         }
         else
         {
-            // This is the case in which AdUnit is set to "adaptive", but Placement is not inline.
-            String placementId = parameters.getThirdPartyAdPlacementId();
-            Object adaptiveWidthObj = parameters.getLocalExtraParameters().get( "adaptive_banner_width" );
-            Object adaptiveMaxHeightObj = parameters.getLocalExtraParameters().get( "inline_adaptive_banner_max_height" );
-            String adaptiveWidth = ( adaptiveWidthObj != null ) ? String.valueOf( adaptiveWidthObj ) : "unknown";
-            String adaptiveMaxHeight = ( adaptiveMaxHeightObj != null ) ? String.valueOf( adaptiveMaxHeightObj ) : "unknown";
-            String adaptiveSizeMessage = String.format( "AdaptivePlacementMismatch:pid-%s w-%s maxh-%s",
-                                                        placementId != null ? placementId : "unknown",
-                                                        adaptiveWidth,
-                                                        adaptiveMaxHeight );
-            VungleMediationLogger.logError( null, adaptiveSizeMessage );
-
             userError( "Please use a Vungle inline placement ID in order to use Vungle adaptive ads" );
             return false;
         }
+    }
+
+    private boolean isAdaptiveAdViewForBannerPlacement(final MaxAdapterResponseParameters parameters) {
+        boolean isAdaptiveServerParams = parameters.getServerParameters().getBoolean("adaptive_banner", false);
+        Object isAdaptiveBannerObj = parameters.getLocalExtraParameters().get("adaptive_banner");
+        boolean isAdaptiveLocalParams = isAdaptiveBannerObj instanceof String && "true".equalsIgnoreCase((String) isAdaptiveBannerObj);
+        boolean isInlinePlacement = VungleAds.isInline(parameters.getThirdPartyAdPlacementId());
+
+        if ((isAdaptiveServerParams || isAdaptiveLocalParams) && !isInlinePlacement) {
+            return true;
+        }
+        return false;
     }
 
     private void updateUserPrivacySettings(final MaxAdapterParameters parameters)

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -467,8 +467,8 @@ public class VungleMediationAdapter
             Object adaptiveMaxHeightObj = parameters.getLocalExtraParameters().get( "inline_adaptive_banner_max_height" );
             String adaptiveWidth = ( adaptiveWidthObj != null ) ? String.valueOf( adaptiveWidthObj ) : "unknown";
             String adaptiveMaxHeight = ( adaptiveMaxHeightObj != null ) ? String.valueOf( adaptiveMaxHeightObj ) : "unknown";
-            String adaptiveSizeMessage = String.format( "AdaptiveBannerSizeMismatch:w-%s|maxh-%s", adaptiveWidth, adaptiveMaxHeight );
-            VungleMediationLogger.logError( adViewAd, adaptiveSizeMessage );
+            String adaptiveSizeMismatchMessage = String.format( "AdaptiveBannerSizeMismatch:w-%s|maxh-%s", adaptiveWidth, adaptiveMaxHeight );
+            VungleMediationLogger.logError( adViewAd, adaptiveSizeMismatchMessage );
         }
     }
 


### PR DESCRIPTION
This commit will add
- logging adaptive banner size mismatch through `VungleMediationLogger` introduced in 7.7.1.
- setting `adapterAdFormat` property in `BaseAd` introduced in 7.7.1.

[AND-5368](https://vungle.atlassian.net/browse/AND-5368)

[AND-5368]: https://vungle.atlassian.net/browse/AND-5368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ