### PR TITLE
[AND-5630] Adapter Logging Phase 2 items

### DIFF
--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -933,6 +933,7 @@ public class VungleMediationAdapter
             {
                 log( "Native " + adFormat.getLabel() + " ad failed to load: no fill" );
                 listener.onAdViewAdLoadFailed( MaxAdapterError.NO_FILL );
+                VungleMediationLogger.logError( ad, "nativeAdObjectMismatch" );
 
                 return;
             }
@@ -1052,6 +1053,7 @@ public class VungleMediationAdapter
             {
                 log( "Native ad failed to load: no fill" );
                 listener.onNativeAdLoadFailed( MaxAdapterError.NO_FILL );
+                VungleMediationLogger.logError( ad, "nativeAdObjectMismatch" );
 
                 return;
             }
@@ -1062,6 +1064,7 @@ public class VungleMediationAdapter
             {
                 e( "Native ad (" + nativeAd + ") does not have required assets." );
                 listener.onNativeAdLoadFailed( MaxAdapterError.MISSING_REQUIRED_NATIVE_AD_ASSETS );
+                VungleMediationLogger.logError( ad, "missingRequiredNativeAdAssets" );
 
                 return;
             }

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -220,10 +220,10 @@ public class VungleMediationAdapter
     {
         if ( interstitialAd == null )
         {
-            VungleMediationLogger.logError( null, "Interstitial ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
             listener.onInterstitialAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
                                                                           MaxAdapterError.AD_NOT_READY.getCode(),
                                                                           MaxAdapterError.AD_NOT_READY.getMessage() ) );
+            VungleMediationLogger.logError( null, "Interstitial ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
             return;
         }
 
@@ -254,10 +254,10 @@ public class VungleMediationAdapter
     {
         if ( appOpenAd == null )
         {
-            VungleMediationLogger.logError( null, "App open ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
             listener.onAppOpenAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
                                                                      MaxAdapterError.AD_NOT_READY.getCode(),
                                                                      MaxAdapterError.AD_NOT_READY.getMessage() ) );
+            VungleMediationLogger.logError( null, "App open ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
             return;
         }
 
@@ -290,10 +290,10 @@ public class VungleMediationAdapter
     {
         if ( rewardedAd == null )
         {
-            VungleMediationLogger.logError( null, "Rewarded ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
             listener.onRewardedAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
                                                                       MaxAdapterError.AD_NOT_READY.getCode(),
                                                                       MaxAdapterError.AD_NOT_READY.getMessage() ) );
+            VungleMediationLogger.logError( null, "Rewarded ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
             return;
         }
 
@@ -1153,7 +1153,6 @@ public class VungleMediationAdapter
             final NativeAd nativeAd = VungleMediationAdapter.this.nativeAd;
             if ( nativeAd == null )
             {
-                VungleMediationLogger.logError( null, "native ad instance is null." );
                 e( "Failed to register native ad views: native ad is null." );
                 return false;
             }
@@ -1161,7 +1160,6 @@ public class VungleMediationAdapter
             View mediaView = getMediaView();
             if ( mediaView == null )
             {
-                VungleMediationLogger.logError( null, "mediaView is null." );
                 e( "Failed to register native ad views: mediaView is null." );
                 return false;
             }

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -562,6 +562,10 @@ public class VungleMediationAdapter
                 break;
         }
 
+        if (adapterError == MaxAdapterError.UNSPECIFIED) {
+            VungleMediationLogger.logError( null, "unspecifiedErrorCode:" +  vungleErrorCode);
+        }
+
         return new MaxAdapterError( adapterError, vungleErrorCode, vungleError.getLocalizedMessage() );
     }
 
@@ -1146,7 +1150,7 @@ public class VungleMediationAdapter
             final NativeAd nativeAd = VungleMediationAdapter.this.nativeAd;
             if ( nativeAd == null )
             {
-                VungleMediationLogger.logError( null, "native ad instance is null." ); // add placement ID
+                VungleMediationLogger.logError( null, "native ad instance is null." );
                 e( "Failed to register native ad views: native ad is null." );
                 return false;
             }

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -207,14 +207,6 @@ public class VungleMediationAdapter
         String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + "interstitial ad for placement: " + placementId + "..." );
 
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing interstitial ad load..." );
-            listener.onInterstitialAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
-
         updateUserPrivacySettings( parameters );
 
         interstitialAd = new InterstitialAd( getContext( activity ), placementId, new AdConfig() );
@@ -250,14 +242,6 @@ public class VungleMediationAdapter
         String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + "app open ad for placement: " + placementId + "..." );
 
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing app open ad load..." );
-            listener.onAppOpenAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
-
         updateUserPrivacySettings( parameters );
 
         appOpenAd = new InterstitialAd( getContext( activity ), placementId, new AdConfig() );
@@ -292,14 +276,6 @@ public class VungleMediationAdapter
         boolean isBiddingAd = AppLovinSdkUtils.isValidString( bidResponse );
         String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + "rewarded ad for placement: " + placementId + "..." );
-
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing rewarded ad load..." );
-            listener.onRewardedAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
 
         updateUserPrivacySettings( parameters );
 
@@ -343,14 +319,6 @@ public class VungleMediationAdapter
 
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + ( isNative ? "native " : "" ) + adFormatLabel + " ad for placement: " + placementId + "..." );
 
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing " + adFormatLabel + " ad load..." );
-            listener.onAdViewAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
-
         updateUserPrivacySettings( parameters );
 
         if ( isNative )
@@ -391,14 +359,6 @@ public class VungleMediationAdapter
         String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + "native ad for placement: " + placementId + "..." );
 
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing interstitial ad load..." );
-            listener.onNativeAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
-
         updateUserPrivacySettings( parameters );
 
         nativeAd = new NativeAd( getContext( activity ), placementId );
@@ -410,11 +370,6 @@ public class VungleMediationAdapter
     //endregion
 
     //region Helper Methods
-
-    private boolean shouldFailAdLoadWhenSdkNotInitialized(final MaxAdapterResponseParameters parameters)
-    {
-        return parameters.getServerParameters().getBoolean( "fail_ad_load_when_sdk_not_initialized", true );
-    }
 
     private boolean isAdaptiveAdViewEnabled(final MaxAdapterResponseParameters parameters)
     {

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -49,8 +49,8 @@ import com.vungle.ads.VungleAdSize;
 import com.vungle.ads.VungleAds;
 import com.vungle.ads.VungleBannerView;
 import com.vungle.ads.VungleError;
+import com.vungle.ads.VungleMediationLogger;
 import com.vungle.ads.VunglePrivacySettings;
-import com.vungle.ads.VungleWrapperFramework;
 import com.vungle.ads.internal.protos.Sdk.SDKError.Reason;
 import com.vungle.ads.internal.ui.view.MediaView;
 
@@ -89,7 +89,7 @@ public class VungleMediationAdapter
 
             initializationStatus = InitializationStatus.INITIALIZING;
 
-            VungleAds.setIntegrationName( VungleWrapperFramework.max, getAdapterVersion() );
+            VungleAds.setIntegrationName( "max", getAdapterVersion() );
 
             // Note: Vungle requires the Application Context
             VungleAds.init( getContext( activity ), appId, new InitializationListener()
@@ -226,18 +226,17 @@ public class VungleMediationAdapter
     @Override
     public void showInterstitialAd(final MaxAdapterResponseParameters parameters, @Nullable final Activity activity, final MaxInterstitialAdapterListener listener)
     {
-        if ( interstitialAd != null && interstitialAd.canPlayAd() )
+        if ( interstitialAd == null )
         {
-            log( "Showing interstitial ad for placement: " + parameters.getThirdPartyAdPlacementId() + "..." );
-            interstitialAd.play( getContext( activity ) );
-        }
-        else
-        {
-            log( "Interstitial ad is not ready: " + parameters.getThirdPartyAdPlacementId() + "..." );
+            VungleMediationLogger.logError( null, "Interstitial ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
             listener.onInterstitialAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                                                                         MaxAdapterError.AD_NOT_READY.getCode(),
-                                                                         MaxAdapterError.AD_NOT_READY.getMessage() ) );
+                                                                          MaxAdapterError.AD_NOT_READY.getCode(),
+                                                                          MaxAdapterError.AD_NOT_READY.getMessage() ) );
+            return;
         }
+
+        log("Showing interstitial ad for placement: " + parameters.getThirdPartyAdPlacementId() + "...");
+        interstitialAd.play(getContext(activity));
     }
 
     //endregion
@@ -269,18 +268,17 @@ public class VungleMediationAdapter
 
     public void showAppOpenAd(@NonNull final MaxAdapterResponseParameters parameters, @Nullable final Activity activity, @NonNull final MaxAppOpenAdapterListener listener)
     {
-        if ( appOpenAd != null && appOpenAd.canPlayAd() )
+        if ( appOpenAd == null )
         {
-            log( "Showing app open ad for placement: " + parameters.getThirdPartyAdPlacementId() + "..." );
-            appOpenAd.play( getContext( activity ) );
-        }
-        else
-        {
-            log( "App open ad is not ready: " + parameters.getThirdPartyAdPlacementId() + "..." );
+            VungleMediationLogger.logError( null, "App open ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
             listener.onAppOpenAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                                                                    MaxAdapterError.AD_NOT_READY.getCode(),
-                                                                    MaxAdapterError.AD_NOT_READY.getMessage() ) );
+                                                                     MaxAdapterError.AD_NOT_READY.getCode(),
+                                                                     MaxAdapterError.AD_NOT_READY.getMessage() ) );
+            return;
         }
+
+        log("Showing app open ad for placement: " + parameters.getThirdPartyAdPlacementId() + "...");
+        appOpenAd.play(getContext(activity));
     }
 
     //endregion
@@ -314,20 +312,18 @@ public class VungleMediationAdapter
     @Override
     public void showRewardedAd(final MaxAdapterResponseParameters parameters, @Nullable final Activity activity, final MaxRewardedAdapterListener listener)
     {
-        if ( rewardedAd != null && rewardedAd.canPlayAd() )
+        if ( rewardedAd == null )
         {
-            log( "Showing rewarded ad for placement: " + parameters.getThirdPartyAdPlacementId() + "..." );
-
-            configureReward( parameters );
-            rewardedAd.play( getContext( activity ) );
-        }
-        else
-        {
-            log( "Rewarded ad is not ready: " + parameters.getThirdPartyAdPlacementId() + "..." );
+            VungleMediationLogger.logError( null, "Rewarded ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
             listener.onRewardedAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                                                                     MaxAdapterError.AD_NOT_READY.getCode(),
-                                                                     MaxAdapterError.AD_NOT_READY.getMessage() ) );
+                                                                      MaxAdapterError.AD_NOT_READY.getCode(),
+                                                                      MaxAdapterError.AD_NOT_READY.getMessage() ) );
+            return;
         }
+
+        log("Showing rewarded ad for placement: " + parameters.getThirdPartyAdPlacementId() + "...");
+        configureReward(parameters);
+        rewardedAd.play(getContext(activity));
     }
 
     //endregion
@@ -1195,19 +1191,15 @@ public class VungleMediationAdapter
             final NativeAd nativeAd = VungleMediationAdapter.this.nativeAd;
             if ( nativeAd == null )
             {
+                VungleMediationLogger.logError( null, "native ad instance is null." ); // add placement ID
                 e( "Failed to register native ad views: native ad is null." );
-                return false;
-            }
-
-            if ( !nativeAd.canPlayAd() )
-            {
-                e( "Failed to play native ad or native ad is registered." );
                 return false;
             }
 
             View mediaView = getMediaView();
             if ( mediaView == null )
             {
+                VungleMediationLogger.logError( null, "mediaView is null." );
                 e( "Failed to register native ad views: mediaView is null." );
                 return false;
             }


### PR DESCRIPTION
This commit will update the adapter code to add adapter logging phase 2 cases:

[AND-5630](https://vungle.atlassian.net/browse/AND-5630)
- Removed canPlayAd check to proper logging by SDK

[AND-5632](https://vungle.atlassian.net/browse/AND-5632)
- Removed SDK initialization check to proper logging by SDK

[AND-5634](https://vungle.atlassian.net/browse/AND-5634)
- Log Native Ad object mismatch case

[AND-5659](https://vungle.atlassian.net/browse/AND-5659)
- Log MAAdapterError.unspecified case

[AND-5630]: https://vungle.atlassian.net/browse/AND-5630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-5632]: https://vungle.atlassian.net/browse/AND-5632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-5634]: https://vungle.atlassian.net/browse/AND-5634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AND-5659]: https://vungle.atlassian.net/browse/AND-5659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ